### PR TITLE
Remove Spring gem completely

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,11 +68,8 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'web-console', '>= 3.3.0'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'brakeman'
   gem 'rubocop', require: false
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,11 +332,6 @@ GEM
       capybara (>= 2.0.0)
       railties (>= 3)
       spinach (>= 0.4)
-    spring (2.0.2)
-      activesupport (>= 4.2)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -412,8 +407,6 @@ DEPENDENCIES
   shoulda-matchers (~> 2.0)
   slim-rails
   spinach-rails
-  spring
-  spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data
   uhura_client!


### PR DESCRIPTION
In shell, run: pkill -f spring
Removed all spring references in Gemfile
In shell, run: bin/spring binstub –remove –all

For reason for removing Spring, see https://fuzzyblog.io/blog/rails/2017/03/20/disabling-spring-in-rails.html