### PR TITLE
Use client_id correlate client with message for status

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,20 +4,22 @@ class HomeController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def index
-
+    @email_status = params['email_status']
+    @sms_status = params['sms_status']
   end
 
   def status
+    sleep 1.second
     ## This is the way how we can get the status of a  message
     client = UhuraClient::MessageClient.new(
       api_key: "b1dcc4b8287a82fe8889", team_id: "1", public_token: "42c50c442ee3ca01378e")
 
-    client.status_of(UhuraClient::Message.new(id: "1"))
+    client.status_of(UhuraClient::Message.new(id: @message.client_id))
   end
 
   def send_message
     # Create message with SMS and Email content
-    message = UhuraClient::Message.new(
+    @message = UhuraClient::Message.new(
       public_token: "42c50c442ee3ca01378e",
       receiver_sso_id: params[:receiver_sso_id],
       email_subject: params[:email_subject],
@@ -27,7 +29,8 @@ class HomeController < ApplicationController
             "button": params[:button]
       },
       template_id: params[:template_id],
-      sms_message: params[:sms_message]
+      sms_message: params[:sms_message],
+      client_id: SecureRandom.uuid
       )
 
     client = UhuraClient::MessageClient.new(
@@ -35,11 +38,14 @@ class HomeController < ApplicationController
       team_id: "1"
     )
     begin
-      client.send_message(message)
+      client.send_message(@message)
       flash[:success] =  'Success!'
     rescue StandardError => error
       flash[:error] =  JSON.parse(error.to_s)['error']['message']
     end
-    redirect_to :root
+    email_sms_status = status
+    redirect_to controller: 'home', action: 'index',
+                email_status: email_sms_status['sendgrid_msg_status'],
+                sms_status: email_sms_status['clearstream_msg_status']
   end
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,6 +1,6 @@
 h1 Uhura Messaging Sample Application
 
-form accept-charset="UTF-8" action="/send_message" method="post"
+form onreset="window.location = '/'" accept-charset="UTF-8" action="/send_message" method="post"
   input name="utf8" type="hidden" value="✓" /
   input name="authenticity_token" type="hidden" value="J7CBxfHalt49OSHp27hblqK20c9PgwJ108nDHX/8Cts="
 
@@ -29,7 +29,7 @@ form accept-charset="UTF-8" action="/send_message" method="post"
         br
 
         label BCC
-        = text_field_tag  'bcc', nil, placeholder: 'John Doe'
+        = text_field_tag  'bcc', nil, placeholder: 'john.doe@xyz.com'
 
         label BCC Name (Ex: John Doe):
         = text_field_tag  'bcc_name', nil, placeholder: 'John Doe'
@@ -37,7 +37,7 @@ form accept-charset="UTF-8" action="/send_message" method="post"
         br
 
         label Reply To
-        = text_field_tag  'reply_to', nil, placeholder: 'John Doe'
+        = text_field_tag  'reply_to', nil, placeholder: 'john.doe@xyz.com'
 
         label Reply To Name (Ex: John Doe):
         = text_field_tag  'reply_to_name', nil, placeholder: 'John Doe'
@@ -91,27 +91,49 @@ form accept-charset="UTF-8" action="/send_message" method="post"
 
   .row
     .column
-      = submit_tag 'Send Message'
-
+        .row
+          .column
+            = submit_tag 'Send Message'
+          .column
+            = submit_tag 'Reset', type: 'reset'
+          .column
+            = submit_tag 'Clear all', type: 'button', onclick: 'clearAll()'
     .column.left10
       - flash.each do |type, message|
         .flash
-          = message
+          - message
 
 javascript:
   function noenter() {
       return !(window.event && window.event.keyCode == 13);
   }
-  fields = document.forms[0].elements
-  fields['email_status'].setAttribute("readonly", "readonly)")
-  fields['sms_status'].setAttribute("readonly", "readonly)")
-  fields['section1'].setAttribute("onKeyPress", "return noenter()")
-  // Set default example values
-  fields['receiver_sso_id'].value = '55357450'
-  fields['email_subject'].value = 'Picnic Saturday Week'
-  fields['template_id'].value = 'd-05d33214e6994b01b577602036bfa9f5'
-  fields['header'].value = 'Dragon Rage'
-  fields['section1'].value = 'imagine you are writing an email. you are in front of the computer. you are operating the computer, clicking a mouse and typing on a keyboard, but the message will be sent to a human over the internet. so you are working before the computer, but with a human behind the computer.'
-  fields['button'].value = 'Count me in!'
-  fields['sms_message'].value = 'Bring Drinks to the Picnic Saturday Week'
+
+  function setDefaults() {
+      fields = document.forms[0].elements
+      fields['email_status'].setAttribute("readonly", "readonly)")
+      fields['sms_status'].setAttribute("readonly", "readonly)")
+      fields['section1'].setAttribute("onKeyPress", "return noenter()")
+      // Set default example values
+      fields['receiver_sso_id'].value = '55357450'
+      fields['email_subject'].value = 'Picnic Saturday Week'
+      fields['template_id'].value = 'd-05d33214e6994b01b577602036bfa9f5'
+      fields['header'].value = 'Dragon Rage'
+      fields['section1'].value = 'imagine you are writing an email. you are in front of the computer. you are operating the computer, clicking a mouse and typing on a keyboard, but the message will be sent to a human over the internet. so you are working before the computer, but with a human behind the computer.'
+      fields['button'].value = 'Count me in!'
+      fields['sms_message'].value = 'Bring Drinks to the Picnic Saturday Week'
+      // Set dynamically
+      fields['email_status'].value = "#{@email_status}"
+      fields['sms_status'].value = "#{@sms_status}"
+  }
+  setDefaults()
+
+  function clearAll() {
+      fields = document.forms[0].elements
+      for (i = 0; i < fields.length; i++) {
+          if (fields[i].type == 'text' || fields[i].type == 'textarea') {
+              fields[i].value = ''
+              fields[i].placeholder = ''
+          }
+      }
+  }
 


### PR DESCRIPTION
Note: Clearstream status yet to be tested

- Update home controller
-- Set email_status and sms_status from params
-- Add client_id to message instance variable
-- Call status to update email and sms status after send message
- Update index (slim) page
-- Reset window.location to root path
-- Update email_status and sms_status from instance variables
-- Fix a few placeholder values
-- Add <Reset> and <Clear all> buttons